### PR TITLE
fix(deploy): set agent image prefix for fork deploys

### DIFF
--- a/deploy/scripts/deploy-production.sh
+++ b/deploy/scripts/deploy-production.sh
@@ -98,6 +98,7 @@ helm_image_args=(
   --set-string web.image.repository="${image_base}/optio-web"
   --set-string optio.image.repository="${image_base}/optio-optio"
   --set-string agent.image.repository="${image_base}/optio-agent-base"
+  --set-string agent.image.prefix="${image_base}/optio-agent-"
   --set-string api.image.tag="${RELEASE_TAG}"
   --set-string web.image.tag="${RELEASE_TAG}"
   --set-string optio.image.tag="${RELEASE_TAG}"


### PR DESCRIPTION
Implements task bb6da0e1-449d-4f29-be82-e29040eb9c0e

## What changed

Reviewed the changes in `develop` vs `main` (fork deploy layer: 9 commits, ~1500 lines across GitHub Actions workflows, deploy scripts, and docs).

Found and fixed a bug in `deploy/scripts/deploy-production.sh`: `helm_image_args` was setting `agent.image.repository` and `agent.image.tag` for the fork owner's registry, but was missing `agent.image.prefix`. This value is stored as `OPTIO_AGENT_IMAGE_PREFIX` in the cluster secret and is used by the API server to construct image URLs for agent presets (node, python, go, rust, full). Without the fix, preset images would be pulled from `ghcr.io/jonwiggins/optio-agent-*` (the upstream owner) instead of the fork owner's GHCR.

**Fix:** added `--set-string agent.image.prefix="${image_base}/optio-agent-"` alongside the other image overrides.

## How to test

1. Run the `Fork Deploy Production` workflow from a forked repository with a valid release tag (e.g. `v0.1.0`).
2. After deploy, inspect the `optio-config` secret in the `optio` namespace:
   ```
   kubectl -n optio get secret optio-config -o jsonpath='{.data.OPTIO_AGENT_IMAGE_PREFIX}' | base64 -d
   ```
   It should show `ghcr.io/<fork-owner>/optio-agent-` rather than `ghcr.io/jonwiggins/optio-agent-`.
3. Create a task using an agent preset (e.g. node) — the pod should pull from the fork owner's registry.